### PR TITLE
Add gsudo to Command Line Tools category

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@
 * [btop4win](https://github.com/aristocratos/btop4win) - Windows port of the famous btop resource monitor. ![Open-Source Software](/assets/opensource.svg)
 * [Chocolatey](https://chocolatey.org/) - Package manager for Windows.
 * [gallery-dl](https://github.com/mikf/gallery-dl) - Command-line program to download image galleries and collections from several image hosting sites. ![Open-Source Software](/assets/opensource.svg)
-* [gsudo](https://gerardog.github.io/gsudo/) - sudo equivalent for Windows, with a similar user-experience as the original Unix/Linux sudo. Allows you to run a command (or re-launch your current shell) with elevated permissions, in the current console window or a new one.  
+* [gsudo](https://gerardog.github.io/gsudo/) - Sudo equivalent for Windows, allows you to run a command with elevated permissions. [![Open-Source Software][oss]](https://github.com/gerardog/gsudo)
 * [Scoop](https://github.com/lukesampson/scoop) - Command-line installer for Windows. ![Open-Source Software](/assets/opensource.svg)
 * [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) - Official Windows package manager from Microsoft. [![Open-Source Software][oss]](https://github.com/microsoft/winget-cli)
 * [yt-dlp](https://github.com/yt-dlp/yt-dlp) - A feature-rich command-line audio/video downloader. ![Open-Source Software](/assets/opensource.svg)


### PR DESCRIPTION
This PR adds gsudo to the Command Line Tools category in the README.md file.

Application URL: https://gerardog.github.io/gsudo/
Repository URL: https://github.com/gerardog/gsudo

Closes #84