### PR TITLE
Add EyeRest – 20-20-20 rule tray app for eye health

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,8 @@
 * [ToDoList](https://abstractspoon.com/) - Feature-rich task management tool. [![Open-Source Software][oss]](https://github.com/abstractspoon/ToDoList)
 * [WordWeb](https://wordweb.info/) - Comprehensive English dictionary.
 * [Saga Reader](https://github.com/sopaco/saga-reader) - A Blazing-Fast and Extremely-Lightweight Internet Reader driven by AI.Supports fetching of search engine information and RSS.
+* [EyeRest](https://github.com/necdetsanli/EyeRest) - A lightweight Windows tray application that gently reminds you to follow the 20–20–20 rule:
+every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 seconds. [![Open-Source Software][oss]](https://github.com/necdetsanli/EyeRest)
 
 ## Proxy and VPN Tools
 


### PR DESCRIPTION
This PR adds **EyeRest** to the Productivity section.

EyeRest is a lightweight Windows tray application that helps users follow the 20–20–20 rule for eye health:

> Every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 seconds.

Key points:
- Runs quietly in the Windows system tray using an ApplicationContext.
- Shows periodic Windows 10/11 toast notifications (with tray balloon fallback).
- Allows configuring the reminder interval and an optional left-click toggle on the tray icon.
- Open source (MIT), no telemetry, no data collection.

Repo: https://github.com/necdetsanli/EyeRest