### PR TITLE
Add 'Local AI' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 * [Games](#game-stores)
 * [Graphics](#graphics)
 * [IDEs](#ides)
+* [Local AI](#local-ai)
 * [Networking](#networking)
 * [Note-taking](#note-taking)
 * [Office Suites](#office-suites)
@@ -282,6 +283,12 @@
 * [Windsurf](https://codeium.com/windsurf) - Agentic IDE with AI flows, multi-file editing and deep contextual awareness.
 * [Zed](https://zed.dev) - A high-performance, multiplayer code editor from the creators of Atom. [![Open-Source Software][oss]](https://github.com/zed-industries/zed)
 
+## Local AI
+
+* [Jan](https://jan.ai) - Offline private AI assistant with CPU/GPU support. [![Open-Source Software][oss]](https://github.com/janhq/jan)
+* [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs with a user-friendly interface.
+* [Ollama](https://ollama.com/) - Get up and running with large language models locally via command line. [![Open-Source Software][oss]](https://github.com/ollama/ollama)
+
 ## Networking
 
 * [Fiddler](https://www.telerik.com/fiddler) - Web debugging proxy.
@@ -326,7 +333,6 @@
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.
-* [Jan](https://jan.ai) - Offline private AI assistant with CPU/GPU support. [![Open-Source Software][oss]](https://github.com/janhq/jan)
 * [Kaas](https://github.com/0xfrankz/Kaas) - Privacy-focused LLM client for multiple AI services. ![Open-Source Software](/assets/opensource.svg)
 * [KatMouse](https://www.ehiti.de/katmouse/) - Universal scrolling utility for Windows.
 * [Keywiz](https://mularahul.github.io/keyviz/) - Real-time keystroke visualization tool. [![Open-Source Software][oss]](https://github.com/mulaRahul/keyviz)


### PR DESCRIPTION
Added a new category for Local AI tools (_running LLMs locally is becoming a key workflow on Windows, I guess_)

- Created 'Local AI' section.
- Added LM Studio and Ollama.
- Moved Jan from the Productivity section to Local AI.