### PR TITLE
Add Kunobi

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@
 ## Developer Utilities
 
 * [Cacher](https://www.cacher.io/) - Syncs and organizes code snippets with Gist integration and IDE plugins.
-* [Kunobi](https://kunobi.ninja) - Rust Kubernetes management from your desktop, with built-in MCP server.
+* [Kunobi](https://kunobi.ninja) - Kubernetes management app written in Rust with MCP integration.
 * [Mamp](https://www.mamp.info/en/) - Runs Apache, MySQL and PHP stack locally.
 * [Pieces](https://pieces.app/) - Uses AI to help capture, organize and reuse code snippets and dev resources.
 * [Velocity](https://velocity.silverlakesoftware.com/) - Browses and searches API documentation without internet connection.


### PR DESCRIPTION
Add [Kunobi](https://kunobi.ninja) to the Developer Utilities section.

Kunobi is a Rust Kubernetes management desktop app with built-in MCP server.