### PR TITLE
Feat: Add Flowtake to Screen Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 ## Screen Capture
 
-* [Flowtake](https://github.com/JNX03/Flowtake) - Open-source screen recording with automatic zoom, cursor smoothing,and video editor. ![Open-Source Software](/assets/opensource.svg) ![star]
+* [Flowtake](https://github.com/JNX03/Flowtake) - Open-source screen recording with automatic zoom, cursor smoothing,and video editor. ![Open-Source Software](/assets/opensource.svg)
 * [Fraps](https://www.fraps.com/) - DirectX/OpenGL game recording utility.
 * [Greenshot](https://github.com/greenshot/greenshot) - Screenshot capture and editing tool. ![Open-Source Software](/assets/opensource.svg)
 * [LICEcap](https://www.cockos.com/licecap/) - Animated GIF screen capture tool.

--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 ## Screen Capture
 
+* [Flowtake](https://github.com/JNX03/Flowtake) - Open-source screen recording with automatic zoom, cursor smoothing,and video editor. ![Open-Source Software](/assets/opensource.svg) ![star]
 * [Fraps](https://www.fraps.com/) - DirectX/OpenGL game recording utility.
 * [Greenshot](https://github.com/greenshot/greenshot) - Screenshot capture and editing tool. ![Open-Source Software](/assets/opensource.svg)
 * [LICEcap](https://www.cockos.com/licecap/) - Animated GIF screen capture tool.

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 ## Screen Capture
 
-* [Flowtake](https://github.com/JNX03/Flowtake) - Open-source screen recording with automatic zoom, cursor smoothing,and video editor. ![Open-Source Software](/assets/opensource.svg)
+* [Flowtake](https://github.com/JNX03/Flowtake) - Open-source screen recorder and timeline editor with automatic zoom, cursor effects, and local MP4 export. ![Open-Source Software](/assets/opensource.svg)
 * [Fraps](https://www.fraps.com/) - DirectX/OpenGL game recording utility.
 * [Greenshot](https://github.com/greenshot/greenshot) - Screenshot capture and editing tool. ![Open-Source Software](/assets/opensource.svg)
 * [LICEcap](https://www.cockos.com/licecap/) - Animated GIF screen capture tool.


### PR DESCRIPTION
## Summary

Adds [Flowtake](https://github.com/JNX03/Flowtake) to the Screen Capture section. Flowtake is an MIT-licensed screen recorder and timeline editor with automatic zoom, cursor effects, and local MP4 export.

The current [v1.6.0 release](https://github.com/JNX03/Flowtake/releases/tag/v1.6.0) publishes Windows x64 EXE, MSI, and portable builds. It is also available from WinGet as `JNX03.Flowtake`.

## Validation

- entry remains alphabetized in Screen Capture
- project URL returns HTTP 200
- confirmed exactly one Flowtake entry
- `git diff --check`
