### PR TITLE
Add GitSquid to Version Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [GitHub Desktop](https://desktop.github.com/) - Electron-based GitHub client. [![Open-Source Software][oss]](https://github.com/desktop/desktop)
 * [GitKraken](https://www.gitkraken.com/) - Cross-platform Git client with intuitive interface.
 * [GitLight](https://github.com/colinlienard/gitlight) - Open-source GitHub & GitLab notifications client. ![Open-Source Software](/assets/opensource.svg)
+* [GitSquid](https://gitsquid.dev/) - Cross-platform Git client with visual commit graph, per-line staging and 10 languages.
 * [Meld](https://meldmerge.org/) - Visual diff and merge tool. [![Open-Source Software][oss]](https://gitlab.gnome.org/GNOME/meld/)
 * [SourceTree](https://www.sourcetreeapp.com/) - Free Git & Mercurial client.
 * [TortoiseGit](https://tortoisegit.org/) - Git client with full shell integration. [![Open-Source Software][oss]](https://github.com/tortoisegit/tortoisegit/)


### PR DESCRIPTION
Adds [GitSquid](https://gitsquid.dev/) to the Version Control section.

GitSquid is a cross-platform Git GUI client for Windows, macOS and Linux, built with Tauri + Rust. Features include a visual commit graph, per-line/per-hunk staging, GitHub / GitLab / Bitbucket integrations, and 10 languages. Free tier available, Pro at €49/year.

Alphabetical placement between GitLight and Meld.