### PR TITLE
Add WobblePic to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ More information in CLAUDE.md and llms.txt.
 * [Oculante](https://github.com/woelper/oculante) - Lightweight, fast and simple image viewer written in rust. ![Open-Source Software](/assets/opensource.svg) ![star]
 * [Paint.NET](https://www.getpaint.net/index.html) - Feature-rich image editing tool.
 * [pngquant](https://pngquant.org/) - Command-line PNG compression utility.
+* [WobblePic](https://wobblepic.com) - Free desktop image viewer with unique soft-body physics that makes images wobble like rubber.
 
 ## IDEs
 


### PR DESCRIPTION
### What
Adds WobblePic to the Graphics section.

### About
WobblePic is a free desktop image viewer (Windows 10/11 + macOS) with a unique feature: soft-body physics simulation. Drag any part of an image and it stretches and wobbles like rubber. It also uses Meta's SAM2 AI model for automatic object segmentation (via DirectML on Windows).

- Website: https://wobblepic.com
- GitHub: https://github.com/wobblepic/WobblePicPublic
- Version: v1.2.1 (actively maintained)
- Free for personal and commercial use

### Checklist
- [x] Entry placed in alphabetical order within Graphics section
- [x] Single-line description under 120 characters
- [x] Not "vibecoded slop" — real utility with unique value proposition (physics simulation + AI segmentation combo)
