### PR TITLE
Add Vibes to Audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ More information in CLAUDE.md and llms.txt.
 * [musikcube](https://musikcube.com/) - Plays music through terminal. [![Open-Source Software][oss]](https://github.com/clangen/musikcube)
 * [Nora](https://noramusic.netlify.app/) - Plays and manages music. [![Open-Source Software][oss]](https://github.com/Sandakan/Nora)
 * [Tenacity](https://tenacityaudio.org/) - A variant of Audacity without telemetry. [![Open-Source Software][oss]](https://codeberg.org/tenacityteam/tenacity)
+* [Vibes](https://vibesdj.io/) - Organizes DJ libraries by mood, energy, and technique. Exports prepped crates to Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ. ![paid]
 
 ## Backup
 


### PR DESCRIPTION
Adds Vibes — a native Windows DJ library organizer — to the Audio section.

- Website: https://vibesdj.io/
- Platform: Windows 10+ (x64)
- License: Commercial (paid)

Vibes sorts DJ tracks by mood, energy, and technique, then exports prepped crates to Rekordbox, Serato DJ, Engine DJ, and Lexicon DJ. Native NSIS installer, built with Tauri. Fits alongside Mixxx (DJ software) and FL Studio (commercial audio) already in the section.