### PR TITLE
Add Instafill.ai under Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ More information in CLAUDE.md and llms.txt.
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.
+* [Instafill.ai](https://instafill.ai) - AI-powered PDF form filler. Auto-completes any PDF form by extracting fields and filling them from saved profiles, uploaded files, or supplied data.
 * [Kaas](https://github.com/0xfrankz/Kaas) - Privacy-focused LLM client for multiple AI services. ![Open-Source Software](/assets/opensource.svg)
 * [KatMouse](https://www.ehiti.de/katmouse/) - Universal scrolling utility for Windows.
 * [Keywiz](https://mularahul.github.io/keyviz/) - Real-time keystroke visualization tool. [![Open-Source Software][oss]](https://github.com/mulaRahul/keyviz)


### PR DESCRIPTION
Adding [Instafill.ai](https://instafill.ai) under **Productivity** (alphabetical position between File Juggler and Kaas).

Instafill.ai is a Windows-compatible AI-powered PDF form filler — uploads a form, extracts fields, and completes them from a saved profile or supplied data. Productivity fits because it eliminates manual data entry on PDFs (forms, applications, intake paperwork).