### PR TITLE
Add dictate.app — Windows push-to-talk dictation via Groq Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ More information in CLAUDE.md and llms.txt.
 * [AutoHotkey](https://autohotkey.com/) - Automation scripting language for Windows. ![Open-Source Software](/assets/opensource.svg)
 * [Beetroot](https://max.nardit.com/beetroot) - Manages clipboard history with AI text transforms and OCR extraction.
 * [Cold Turkey](https://getcoldturkey.com) - Website blocker with strict enforcement mechanisms.
+* [dictate.app](https://dictate-app.pages.dev) - Push-to-talk voice dictation via Groq Whisper. ~200ms latency, auto-pastes text at cursor. 7-day trial. ![paid]
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.


### PR DESCRIPTION
**dictate.app** is a Windows push-to-talk voice dictation app built on Groq Whisper.

- ~200ms transcription latency
- Auto-pastes text directly at cursor (any app, any text field)
- Global hotkey (remappable)
- 7-day free trial
- Site: https://dictate-app.pages.dev

Fits the Productivity section alongside TypeWhisper and other voice/keyboard productivity tools.