### PR TITLE
Add talat to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ More information in CLAUDE.md and llms.txt.
 * [PhraseVault](https://phrasevault.app/) - Expands text snippets with fuzzy search, usage-based prioritization, and local-only data storage. ![paid]
 * [STranslate](https://github.com/ZGGSONG/STranslate) - A ready-to-go translation ocr tool developed with WPF ![Open-Source Software](/assets/opensource.svg)
 * [Super Productivity](https://super-productivity.com/) - Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration. [![Open-Source Software][oss]](https://github.com/johannesjo/super-productivity)
+* [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine. ![paid]
 * [Taskade](https://taskade.com/) - Collaborative task management with real-time sync.
 * [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription with privacy-first approach. System-wide dictation via global hotkey. [![Open-Source Software][oss]](https://github.com/TypeWhisper/typewhisper-win)
 * [Timelens](https://timlens.wireway.ch) - Cross-platform time tracking software. [![Open-Source Software][oss]](https://github.com/0pandadev/timelens)


### PR DESCRIPTION
Adding talat to Productivity. It's an on-device meeting recorder and transcriber; TypeWhisper (the closest existing entry on the list) already sits in this category, so it felt like the right home even though the section name is generic.

Slotted alphabetically before Taskade. It's a paid, closed-source app, so I've added the paid marker and left the OSS icon off.

One small note: the brand is intentionally lowercase ("talat", not "Talat"), same as musikcube and f.lux already on the list.

Cheers,
Nick