### PR TITLE
Add WhisperSubTranslate to Video Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [ScreenToGif](https://www.screentogif.com/) - Records screen areas and saves as GIF or video. [![Open-Source Software][oss]](https://github.com/NickeManarin/ScreenToGif/)
 * [Shotcut](https://www.shotcut.org/download/) - Video editor with native timeline filtering. [![Open-Source Software][oss]](https://github.com/mltframework/shotcut)
 * [Shutter Encoder](https://www.shutterencoder.com/) - Converts between hundreds of media formats with processing options.
+* [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) - Generates translated subtitles from any video file using whisper.cpp and a local LLM (or DeepL/OpenAI/Gemini). [![Open-Source Software][oss]](https://github.com/Blue-B/WhisperSubTranslate)
 * [VLC](https://www.videolan.org/vlc/index.html) - Plays damaged/incomplete media files and network streams. [![Open-Source Software][oss]](https://github.com/videolan/vlc)
 
 ## Virtualization


### PR DESCRIPTION
Adds [WhisperSubTranslate](https://github.com/Blue-B/WhisperSubTranslate) to Video Utilities.

Free Windows desktop Electron app (GPL-3.0) that generates translated subtitles from any video file. Local speech-to-text via whisper.cpp (CUDA/CPU), translation via local LLM or DeepL/OpenAI/Gemini. 14 target languages. Portable build available.