### PR TITLE
Add Glyph to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 ## Text Editors
 
+* [Glyph](https://github.com/hamidfzm/glyph) - Cross-platform Markdown viewer and editor with live preview, KaTeX math, Mermaid diagrams, and AI assistance. [![Open-Source Software][oss]](https://github.com/hamidfzm/glyph)
 * [GVim](https://www.vim.org/download.php#pc) - Highly configurable text editor optimized for efficiency. [![Open-Source Software][oss]](https://github.com/vim/vim-win32-installer/releases/tag/v9.1.0679)
 * [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, focus mode, and diff viewer. Built with Tauri v2.
 * [LazyVim](https://www.lazyvim.org/) - Customizable Neovim configuration framework. [![Open-Source Software][oss]](https://github.com/LazyVim/LazyVim)


### PR DESCRIPTION
Adds **Glyph** to the **Text Editors** section, in alphabetical order (before GVim).

`* [Glyph](https://github.com/hamidfzm/glyph) - Cross-platform Markdown viewer and editor with live preview, KaTeX math, Mermaid diagrams, and AI assistance. [![Open-Source Software][oss]](https://github.com/hamidfzm/glyph)`

Glyph is an open-source (MIT) native markdown viewer/editor built with Tauri 2 + React 19, with a Windows installer. Open-Source icon included, alphabetical order preserved, no trailing whitespace, single suggestion.
