### PR TITLE
Add Cinema to Command Line Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ More information in CLAUDE.md and llms.txt.
 
 * [btop4win](https://github.com/aristocratos/btop4win) - Windows port of the famous btop resource monitor. ![Open-Source Software](/assets/opensource.svg)
 * [Chocolatey](https://chocolatey.org/) - Package manager for Windows.
+* [Cinema](https://github.com/marm00/cinema) - Command-line multiviewer for local and online media with custom layouts. ![Open-Source Software](/assets/opensource.svg)
 * [Fastfetch](https://github.com/fastfetch-cli/fastfetch) - A maintained, feature-rich and performance oriented, neofetch like system information tool. ![Open-Source Software](/assets/opensource.svg)
 * [gallery-dl](https://github.com/mikf/gallery-dl) - Command-line program to download image galleries and collections from several image hosting sites. ![Open-Source Software](/assets/opensource.svg)
 * [gitty](https://github.com/Omibranch/gitty) - Git workflow CLI. Stage, commit, and push in one command, with interactive conflict resolution. ![Open-Source Software](/assets/opensource.svg)


### PR DESCRIPTION
Adds [Cinema](https://github.com/marm00/cinema) to the Command Line Tools section.

This is a free open source C project to watch multiple Twitch streams (and other media) at once. Browserless and with a ton of QoL features and configuration, compared to online multiviewers.

It has custom layouts, command previews with autocomplete (full-fledged REPL using [VT sequences](https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences) and WinAPI), shuffle, JSON ipc to communicate with mpv (multithreaded), file search, tags, macros to combine commands, config file, amongst other features built from scratch, MIT license.

Build script and binaries for Windows.