### PR TITLE
Add CapyBro to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ More information in CLAUDE.md and llms.txt.
 
 * [AutoHotkey](https://autohotkey.com/) - Automation scripting language for Windows. ![Open-Source Software](/assets/opensource.svg)
 * [Beetroot](https://max.nardit.com/beetroot) - Manages clipboard history with AI text transforms and OCR extraction.
+* [CapyBro](https://capybro.app) - AI text rewriter, grammar fixer, and translator. Edit any selected text in any app via global hotkey, using cloud (OpenRouter) or fully-local (Ollama) models. [![Open-Source Software][oss]](https://github.com/phantasmat2018/capy-bro)
 * [Cold Turkey](https://getcoldturkey.com) - Website blocker with strict enforcement mechanisms.
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.


### PR DESCRIPTION
CapyBro is an open-source (MIT) Windows tray utility that brings AI text editing to any app via a global hotkey. Select text in Word, browser, email, or any field, press Ctrl+Shift+E, and the AI rewrites it in place.

Two backends: cloud via OpenRouter (GPT, Claude, Gemini), or fully offline via local Ollama for privacy-sensitive work.

Native .NET 8 + WPF, 49 MB installer, ~80 MB RAM at idle (not Electron). Free version is feature-complete; optional $19 one-time Pro adds usage stats, history export, premium prompt packs.

- Website: https://capybro.app
- Source: https://github.com/phantasmat2018/capy-bro
- License: MIT

Inserted in Productivity section, alphabetically between Beetroot and Cold Turkey.