### PR TITLE
Add Sifty to System Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [scrcpy](https://github.com/Genymobile/scrcpy) - Easily mirror and control your Android devices on computers via USB or WiFi. ![Open-Source Software](/assets/opensource.svg)
 * [SDelete](https://technet.microsoft.com/en-us/sysinternals/sdelete.aspx) - Secure file deletion command-line utility.
 * [Servy](https://github.com/aelassas/servy) - A tool to turn any app into a native Windows service with powerful configuration and management options (a modern alternative to NSSM and WinSW).
+* [Sifty](https://github.com/Vortrix5/sifty) - CLI and terminal-UI maintenance tool that cleans junk, analyzes disk usage, finds duplicate files, and manages apps, updates and startup programs. Previews every change by default and sends deletions to the Recycle Bin. ![Open-Source Software](/assets/opensource.svg)
 * [SpeedCrunch](https://speedcrunch.org/) - Powerful scientific calculator. [![Open-Source Software][oss]](https://bitbucket.org/heldercorreia/speedcrunch/)
 * [SyncThing](https://syncthing.net/) - Peer-to-peer file synchronization tool. [![Open-Source Software][oss]](https://github.com/syncthing/syncthing)
 * [Twinkle Tray](https://twinkletray.com/) - Easily manage the brightness levels of multiple monitors. [![Open-Source Software][oss]](https://github.com/xanderfrangos/twinkle-tray)


### PR DESCRIPTION
Adding Sifty, an open-source Windows maintenance tool I build and maintain.

It cleans junk and app caches, analyzes disk usage, finds duplicate files, and manages installed apps, updates and startup programs, from either a scriptable CLI or a full-screen terminal UI. The part I cared about most is safety: every destructive command is dry-run by default, deletions go to the Recycle Bin (with an undo) instead of being wiped, and system paths like `C:\Windows` and `Program Files` are refused outright.

It sits naturally next to the cleaners already in this section (BleachBit, CrunchyCleaner, CleanMyPC). MIT licensed, written in Python.

- Added under **System Utilities** in alphabetical order (between Servy and SpeedCrunch)
- Followed the existing entry format with the open-source badge

Repo: https://github.com/Vortrix5/sifty
