### PR TITLE
Add Slate - OLED-friendly Windows text editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ More information in CLAUDE.md and llms.txt.
 * [Nani Translate](https://nani.now) - Fast AI translator that explains and refines your phrasing.
 * [Ninite](https://ninite.com/) - Streamlined software installation utility.
 * [PhraseVault](https://phrasevault.app/) - Expands text snippets with fuzzy search, usage-based prioritization, and local-only data storage. ![paid]
+* [Slate](https://github.com/MiaAI-Lab/Slate) - A lightweight, OLED-friendly Windows text editor with live Markdown preview, multi-tab editing, and zero telemetry. True-black OLED theme, local-first, no cloud. ![Open-Source Software](/assets/opensource.svg)
 * [STranslate](https://github.com/ZGGSONG/STranslate) - A ready-to-go translation ocr tool developed with WPF ![Open-Source Software](/assets/opensource.svg)
 * [Super Productivity](https://super-productivity.com/) - Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration. [![Open-Source Software][oss]](https://github.com/johannesjo/super-productivity)
 * [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine. ![paid]


### PR DESCRIPTION
Add [Slate](https://github.com/MiaAI-Lab/Slate) under the Productivity section.

Slate is a Windows text editor built with Tauri 2, Rust, and Svelte 5:
- OLED true-black theme (pure #000000)
- Local-first, zero telemetry, no cloud
- Live GFM preview with split view
- Multi-tab editing
- ~6MB installer