### PR TITLE
Add FotoApp to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ More information in CLAUDE.md and llms.txt.
 * [Blender](https://www.blender.org/) - Professional 3D creation suite. [![Open-Source Software][oss]](https://developer.blender.org/)
 * [Ente Photos](https://ente.io/) - Store and share your photos with absolute privacy. [![Open-Source Software][oss]](https://github.com/ente-io/ente)
 * [Figma](https://www.figma.com/) - Collaborative interface design tool. ![star]
+* [FotoApp](https://github.com/boulbaal/fotoApp) - Local-only photo and video organizer with duplicate detection, GPS map, RAW support and Google Takeout import. No cloud or account. [![Open-Source Software][oss]](https://github.com/boulbaal/fotoApp)
 * [GIMP](https://www.gimp.org/) - Feature-rich image editor. [![Open-Source Software][oss]](https://www.gimp.org/source/)
 * [Inkscape](https://inkscape.org/en/) - Professional vector graphics editor. [![Open-Source Software][oss]](https://gitlab.com/inkscape/inkscape)
 * [Krita](https://krita.org/) - Professional digital painting program. [![Open-Source Software][oss]](https://krita.org/en/download/krita-desktop/)


### PR DESCRIPTION
Adds **FotoApp** to the Graphics category (alphabetical order).

FotoApp is a free, open-source (ISC) **local-only** desktop app to organize photos & videos on Windows (also macOS/Linux): duplicate detection, GPS map (OpenStreetMap), RAW support, Google Takeout import, smart export. No cloud, no account, no telemetry.

Disclosure: I'm the author.

Repo: https://github.com/boulbaal/fotoApp