### PR TITLE
Add ShotsGlow to Screenshot section

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [Greenshot](https://getgreenshot.org/) - Greenshot is a light-weight screenshot software tool for Windows. [![Open-Source Software][oss]](https://github.com/greenshot/greenshot)
 * [Lightshot](https://app.prntscr.com/en/index.html) - A fast and intuitive screenshot tool that allows capturing and editing images instantly.
 * [ShareX](https://getsharex.com/) - Powerful, open-source screenshot and screen recording tool with advanced editing options. [![Open-Source Software][oss]](https://github.com/ShareX/ShareX) ![star]
+* [ShotsGlow](https://shotsglow.com/) - Screenshot tool with gradient backdrops, annotation, redaction and on-device AI background removal. ![paid]
 
 ## Security
 


### PR DESCRIPTION
Adding my screenshot tool, ShotsGlow. It's a native Windows app. You capture a region, drop it on a gradient backdrop, add arrows and text, blur out sensitive parts (the blur survives a later crop), and remove backgrounds with an AI model that runs fully on-device, so nothing gets uploaded. Paid, $9 one-time, no subscription. Put it after ShareX to keep the section alphabetical and gave it the paid badge.