### PR TITLE
docs: add Markra

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [GVim](https://www.vim.org/download.php#pc) - Highly configurable text editor optimized for efficiency. [![Open-Source Software][oss]](https://github.com/vim/vim-win32-installer/releases/tag/v9.1.0679)
 * [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, focus mode, and diff viewer. Built with Tauri v2.
 * [LazyVim](https://www.lazyvim.org/) - Customizable Neovim configuration framework. [![Open-Source Software][oss]](https://github.com/LazyVim/LazyVim)
+* [Markra](https://markra.app/) - Local-first WYSIWYG Markdown editor with native AI review. [![Open-Source Software][oss]](https://github.com/murongg/markra)
 * [MDLook](https://mdlook.com) - Portable offline Markdown editor using WebView2 instead of Electron.
 * [Neovim](https://neovim.io/) - Modern, extensible terminal-based editor. [![Open-Source Software][oss]](https://github.com/neovim/neovim)
 * [Notepad++](https://notepad-plus-plus.org/) - Feature-rich source code editor. [![Open-Source Software][oss]](https://github.com/notepad-plus-plus/notepad-plus-plus)


### PR DESCRIPTION
## Summary
- Adds Markra to the `Text Editors` section.
- Links to the project website and open-source GitHub repository.

## Validation
- `git diff --check` passed.
- `npm_config_cache=/Users/murong/Documents/myopensource/_awesome-submissions/.npm-cache npm exec --yes --package awesome-lint@0.18.0 -- awesome-lint README.md` was attempted, but the existing README currently reports unrelated lint issues and a GitHub API rate limit; the new Markra line was not reported in the lint output.