### PR TITLE
Add DeskRipple to Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ More information in CLAUDE.md and llms.txt.
 ## Customization
 
 * [7+ Taskbar Tweaker](https://rammichael.com/7-taskbar-tweaker) - Modifies Windows taskbar behavior.
+* [DeskRipple](https://deskripple.com/) - Adds desktop folder icons that expand into shortcut panels.
 * [OpenShell](https://github.com/Open-Shell/Open-Shell-Menu) - Restores traditional Start Menu interface. ![Open-Source Software](/assets/opensource.svg)
 * [EarTrumpet](https://eartrumpet.app/) - Controls volume per application. [![Open-Source Software][oss]](https://github.com/File-New-Project/EarTrumpet)
 * [FluentFlyout](https://fluentflyout.com/) - Displays media controls, lock key status and taskbar widgets in native-looking Fluent 2 flyouts. [![Open-Source Software][oss]](https://github.com/unchihugo/FluentFlyout)


### PR DESCRIPTION
### Add DeskRipple

- **Website:** https://deskripple.com/
- **What it is:** A Windows 11 desktop utility — folder icons sit on the desktop (behind your windows, like native icons) and expand into shortcut panels on hover or click; five layouts (Grid, Fan, Column, Row, Ring). Drag in shortcuts/links/files and it keeps its own copies, so a dock survives the original being moved or deleted.
- **Category:** Customization — inserted alphabetically, right after "7+ Taskbar Tweaker".
- **License:** Freeware, closed source — so no `![oss]` and no `![paid]` marker (free during the public beta).
- **Platform:** Windows 11 64-bit. Code-signed with Microsoft Trusted Signing; signed installer + portable ZIP on GitHub Releases: https://github.com/DeskRipple/deskripple/releases/latest

One entry, alphabetical, no marketing language — per CONTRIBUTING.
