### PR TITLE
Add GitBench to Version Control list

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 * [DevHub](https://devhubapp.com/) - GitHub notifications on your desktop as a tray app. [![Open-Source Software][oss]](https://github.com/devhubapp/devhub)
 * [Fork](https://git-fork.com/) - Fast and friendly Git client for Windows and Mac.
+* [GitBench](https://gitbench.builtbyzee.com/) - Native, GPU-accelerated Git client for managing many repositories at once with a visual commit graph and inline diffs. [![Open-Source Software][oss]](https://github.com/Zeejfps/GitBench)
 * [Git Extensions](https://gitextensions.github.io/) - Powerful and user-friendly Git UI. [![Open-Source Software][oss]](https://github.com/gitextensions/gitextensions)
 * [GitHub Desktop](https://desktop.github.com/) - Electron-based GitHub client. [![Open-Source Software][oss]](https://github.com/desktop/desktop)
 * [GitKraken](https://www.gitkraken.com/) - Cross-platform Git client with intuitive interface.


### PR DESCRIPTION
Adds **GitBench** to the list.

GitBench is a free, open-source (MIT) desktop Git client focused on working across many repositories at once: every repo is grouped in one sidebar for instant switching, with a visual commit graph, inline diffs, branch management, and worktree/stash/submodule support. Native, GPU-accelerated builds for Windows, macOS, and Linux.

- Website: https://gitbench.builtbyzee.com/
- Source: https://github.com/Zeejfps/GitBench