### PR TITLE
Add WinDiskCleanup — disk cleanup for Windows developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ More information in CLAUDE.md and llms.txt.
 * [Mamp](https://www.mamp.info/en/) - Runs Apache, MySQL and PHP stack locally.
 * [Pieces](https://pieces.app/) - Uses AI to help capture, organize and reuse code snippets and dev resources.
 * [Velocity](https://velocity.silverlakesoftware.com/) - Browses and searches API documentation without internet connection.
+* [WinDiskCleanup](https://github.com/AbdulWaseaDev/WinDiskCleanup) - Cleans 31 targets in one run: browser caches, npm/pip/Yarn/NuGet/Maven/Gradle/Cargo/Go/Flutter caches, inactive node_modules/venvs, build artifacts, WSL/Docker vhdx, and more. [![Open-Source Software][oss]](https://github.com/AbdulWaseaDev/WinDiskCleanup) ![star]
 * [Xampp](https://www.apachefriends.org/index.html) - Bundles Apache, MariaDB, PHP and Perl for local development.
 
 ## Email


### PR DESCRIPTION
## Description

[WinDiskCleanup](https://github.com/AbdulWaseaDev/WinDiskCleanup) is an open-source PowerShell script that frees disk space by cleaning 31 targets in a single run.

## What it cleans

- Browser caches (Chrome, Edge, Firefox, Brave — all profiles, auto-detected)
- Package manager caches: npm, pip, Yarn, pnpm, NuGet, Maven, Gradle, Cargo, Go, Flutter/Dart
- Inactive \
ode_modules\ and Python venvs (auto-scanned, asks before deleting)
- Build artifacts (\in/obj/dist/target/.next\) with marker-file detection
- \git clean -fdX\ across all repos in project folders
- Temp files, Windows Update cache, DISM WinSxS, crash dumps, Recycle Bin
- VS Code duplicate extensions, Microsoft Teams cache
- WSL \pt clean\, Docker prune, vhdx compaction

## Why Developer Utilities

It is a developer-focused tool. All package managers and tools are auto-detected — if something is not installed, that step is silently skipped. No telemetry, no network calls, works fully offline.

- License: MIT
- Repo: https://github.com/AbdulWaseaDev/WinDiskCleanup