### PR TITLE
Add Endstate to Backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ More information in CLAUDE.md and llms.txt.
 ## Backup
 
 * [Duplicati](https://www.duplicati.com/) - Stores encrypted backups online. [![Open-Source Software][oss]](https://github.com/duplicati/duplicati)
+* [Endstate](https://substratesystems.io/endstate) - Saves your installed apps (via winget) and settings to one portable file and reinstalls them on a fresh Windows install. [![Open-Source Software][oss]](https://github.com/Artexis10/endstate)
 * [Kopia](https://kopia.io/) - Creates incremental backups with client-side encryption and cloud support. [![Open-Source Software][oss]](https://github.com/kopia/kopia)
 * [Restic](https://restic.net/) - Backs up data to various storage types. [![Open-Source Software][oss]](https://github.com/restic/restic/tree/master)
 


### PR DESCRIPTION
Adds [Endstate](https://substratesystems.io/endstate) under **Backup**.

Endstate is a free, open-source (Apache 2.0) Windows app that scans your installed apps (via winget) and settings, saves them to one portable file, and reinstalls everything on a fresh Windows install. Engine: https://github.com/Artexis10/endstate

- Entry placed alphabetically in the Backup section
- Open-source badge linked to the engine repo, matching the existing format
- No other lines changed