### PR TITLE
Add MoonProxy to Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ More information in CLAUDE.md and llms.txt.
 ## Networking
 
 * [Fiddler](https://www.telerik.com/fiddler) - Web debugging proxy.
+* [MoonProxy](https://moonproxy.app) - An open-source cross-platform FRP desktop GUI client for macOS and Windows. [![Open-Source Software][oss]](https://github.com/MoonProxyHQ/moonproxy-desktop)
 * [Nmap](https://nmap.org/) - A free, open-source network scanner used for discovering hosts, services, and vulnerabilities on computer networks through advanced port scanning and OS detection techniques. [![Open-Source Software][oss]](https://github.com/nmap/nmap)
 * [Sniffnet](https://sniffnet.net/) - Network monitoring tool to help you easily keep track of your Internet traffic. [![Open-Source Software][oss]](https://github.com/GyulyVGC/sniffnet)
 * [Wireshark](https://www.wireshark.org/) - Network protocol analyzer. [![Open-Source Software][oss]](https://www.wireshark.org/docs/wsdg_html_chunked/ChIntroDevelopment.html)


### PR DESCRIPTION
## Summary

Added [MoonProxy](https://moonproxy.app) to the **Networking** category.

MoonProxy is an open-source cross-platform FRP (Fast Reverse Proxy) desktop GUI client for macOS and Windows.

- **License:** MIT
- **Website:** https://moonproxy.app
- **Source:** https://github.com/MoonProxyHQ/moonproxy-desktop

It is a Windows desktop application, so it fits well in the Networking section alongside tools like Fiddler and Wireshark.