### PR TITLE
Add Tinta

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [Notepad2](https://www.flos-freeware.ch/notepad2.html) - Lightweight Notepad replacement with enhanced features. ![Open-Source Software](/assets/opensource.svg)
 * [Sublime Text](https://www.sublimetext.com/3) - Advanced text editor with extensive plugin ecosystem.
 * [Text Forge](https://text-forge.github.io/docs) - Lighweight, hackable, and highly modular text & code editor. ![Open-Source Software](/assets/opensource.svg)
+* [Tinta](https://tinta.cc/) - Fast, lightweight Markdown viewer using Direct2D instead of Electron. [![Open-Source Software][oss]](https://github.com/oipoistar/tinta)
 
 ## Version Control
 


### PR DESCRIPTION
Adds [Tinta](https://tinta.cc) to **Text Editors** (alphabetical, after Text Forge).

Tinta is a fast, lightweight Markdown viewer for Windows — native C++ with Direct2D/DirectWrite rendering, single portable exe under 1 MB, ~200 ms startup, MIT licensed. 10 themes, table of contents, search, and an edit mode with live preview.

- Source: https://github.com/oipoistar/tinta
- I'm the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)