### PR TITLE
Add Orbital

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ More information in CLAUDE.md and llms.txt.
 * [Cacher](https://www.cacher.io/) - Syncs and organizes code snippets with Gist integration and IDE plugins.
 * [Kunobi](https://kunobi.ninja) - Kubernetes management app written in Rust with MCP integration.
 * [Mamp](https://www.mamp.info/en/) - Runs Apache, MySQL and PHP stack locally.
+* [Orbital](https://github.com/zqiren/Orbital) - Local-first desktop agent runtime that keeps its memory in a plain-markdown folder and dispatches Claude Code and Codex as sub-agents with approvals, budgets, and an OS-sandboxed built-in shell. [![Open-Source Software][oss]](https://github.com/zqiren/Orbital)
 * [Pieces](https://pieces.app/) - Uses AI to help capture, organize and reuse code snippets and dev resources.
 * [Velocity](https://velocity.silverlakesoftware.com/) - Browses and searches API documentation without internet connection.
 * [Xampp](https://www.apachefriends.org/index.html) - Bundles Apache, MariaDB, PHP and Perl for local development.


### PR DESCRIPTION
Individual PR adding one app to **Developer Utilities**, in alphabetical order (between Mamp and Pieces), with the open-source icon per the list format.

Orbital is a free, open-source (GPL-3.0) local-first desktop app for Windows and macOS. It runs coding agents for you — dispatching Claude Code and Codex as sub-agents — while keeping the agent's persistent memory as a plain-markdown folder on disk, plus approvals, per-project budgets, and an OS-sandboxed built-in shell.

Disclosure: I'm the author of Orbital.