### PR TITLE
Add Voxis to tools list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ More information in CLAUDE.md and llms.txt.
 * [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription with privacy-first approach. System-wide dictation via global hotkey. [![Open-Source Software][oss]](https://github.com/TypeWhisper/typewhisper-win)
 * [Timelens](https://timlens.wireway.ch) - Cross-platform time tracking software. [![Open-Source Software][oss]](https://github.com/0pandadev/timelens)
 * [ToDoList](https://abstractspoon.com/) - Feature-rich task management tool. [![Open-Source Software][oss]](https://github.com/abstractspoon/ToDoList)
+* [Voxis](https://voxislive.com) - Speaks a live translation of whatever your PC is playing (games, films, streams, calls) instead of showing subtitles. 79 languages, no virtual audio cable needed. ![paid]
 * [WordWeb](https://wordweb.info/) - Comprehensive English dictionary.
 * [Saga Reader](https://github.com/sopaco/saga-reader) - A Blazing-Fast and Extremely-Lightweight Internet Reader driven by AI.Supports fetching of search engine information and RSS.
 * [EyeRest](https://github.com/necdetsanli/EyeRest) - A lightweight Windows tray application that gently reminds you to follow the 20–20–20 rule:


### PR DESCRIPTION
Adds Voxis under Productivity, alphabetically before WordWeb.

Every other translation tool in this space prints subtitles on screen. Voxis produces an actual translated voice, so your eyes stay on the game or the film. It captures system audio via WASAPI process loopback while excluding its own PID — which is what lets it work without VB-CABLE and without re-translating its own output.

Shipping on the Microsoft Store; engine source at https://github.com/DavutAkca/voxislive.

Badge: ![paid]. The free tier has changed since I opened this, so to be accurate: a new account gets 15 minutes of the full engine once, and after that 10 minutes every day, indefinitely — the daily minutes run on a lighter engine that speaks with a local voice. So it stays usable for free, but it is not free software: the engine is source-available under PolyForm Noncommercial, not OSI open source, so I'm deliberately not claiming the ![oss] badge.

Disclosure: I'm the developer. Happy to be told it's not a fit.
