### PR TITLE
Add YAKC to Screen Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [LICEcap](https://www.cockos.com/licecap/) - Animated GIF screen capture tool.
 * [OBS Studio](https://obsproject.com/) - Free and open source software for video recording and live streaming. [![Open-Source Software][oss]](https://github.com/obsproject/obs-studio) ![star]
 * [Snipping Tool](https://support.microsoft.com/en-in/help/13776/windows-use-snipping-tool-to-capture-screenshots) - Built-in Windows screenshot utility.
+* [YAKC](https://github.com/iammodev/YAKC) - Keystroke and mouse-click visualizer for screencasts, streaming and presentations. [![Open-Source Software][oss]](https://github.com/iammodev/YAKC)
 * [ZoomIt](https://technet.microsoft.com/en-us/sysinternals/zoomit.aspx) - Screen zoom and annotation tool for presentations.
 
 ## Screenshot


### PR DESCRIPTION
Adds **YAKC (Yet Another Key Caster)** to Screen Capture.

YAKC is an open-source keystroke & mouse-click visualizer for screencasts, streaming and presentations. It ships x64 and ARM64 Windows installers (and also runs on macOS and Linux).

- Repo: https://github.com/iammodev/YAKC
- Releases: https://github.com/iammodev/YAKC/releases/latest

Entry is alphabetical and follows the existing `[![Open-Source Software][oss]]` format.