### PR TITLE
Add FluxDown to File Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ More information in CLAUDE.md and llms.txt.
 * [File pilot](https://filepilot.tech/) - Next-gen file explorer. Engineered entirely from scratch for light-speed performance, featuring a modern and robust interface.  
 * [FileOptimizer](https://nikkhokkho.sourceforge.io/static.php?page=FileOptimizer) - Lossless file size optimizer for multiple formats.
 * [FileZilla](https://filezilla-project.org/) - FTP, FTPS and SFTP client. [![Open-Source Software][oss]](https://download.filezilla-project.org/client/)
+* [FluxDown](https://fluxdown.zerx.dev) - Multi-protocol download manager with IDM-style dynamic segmentation for HTTP, FTP, BitTorrent and HLS/DASH streams. [![Open-Source Software][oss]](https://github.com/zerx-lab/FluxDown)
 * [FreeFileSync](https://www.freefilesync.org/) - File and folder backup with multiple sync modes.
 * [fselect](https://github.com/jhspetersson/fselect) - SQL-like file search utility.
 * [One Commander](https://onecommander.com/) - Modern file manager with miller columns.


### PR DESCRIPTION
FluxDown is a free and open-source download manager for Windows 10/11 (x64 and ARM64).

It runs a Rust + Tokio engine, splits downloads into segments dynamically the way IDM does, and handles HTTP/HTTPS, FTP, BitTorrent, eD2K, HLS and DASH. Download state lives in SQLite so downloads survive a crash or reboot. There are Chrome, Edge and Firefox extensions for taking over browser downloads. No ads, no telemetry, no account.

- Site: https://fluxdown.zerx.dev
- Source: https://github.com/zerx-lab/FluxDown (AGPL-3.0)

There is no downloads category in the list, so I put it under File Management in alphabetical order between FileZilla and FreeFileSync. Happy to move it to a new Downloaders section instead if you would rather have one.