### PR TITLE
Add MatrixShader to Terminal section

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [ConEmu](https://github.com/Maximus5/ConEmu) - Customizable terminal with tabs, splits, and quake-style dropdown.
 * [FluentTerminal](https://github.com/felixse/FluentTerminal) - UWP-based modern terminal emulator.
 * [Kitty](https://www.9bis.net/kitty/) - Enhanced PuTTY with additional features.
+* [MatrixShader](https://github.com/matrixshader/matrix-shader) - GPU-powered Matrix rain shader for Windows Terminal with multi-window color presets and hotkeys.
 * [MobaXterm](https://mobaxterm.mobatek.net/) - Enhanced terminal with X server and SSH client.
 * [MTPuTTY](https://ttyplus.com/multi-tabbed-putty/) - Multi-tabbed PuTTY client.
 * [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) - SSH and telnet client.


### PR DESCRIPTION
Adds MatrixShader to the Terminal section.

MatrixShader is a GPU-powered Windows Terminal shader tool with multi-window color presets, hotkeys, and live parameter control.

Links:
- GitHub: https://github.com/matrixshader/matrix-shader
- Website: https://matrixshader.com