### PR TITLE
Add Torto ebook reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ More information in CLAUDE.md and llms.txt.
 * [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription with privacy-first approach. System-wide dictation via global hotkey. [![Open-Source Software][oss]](https://github.com/TypeWhisper/typewhisper-win)
 * [Timelens](https://timlens.wireway.ch) - Cross-platform time tracking software. [![Open-Source Software][oss]](https://github.com/0pandadev/timelens)
 * [ToDoList](https://abstractspoon.com/) - Feature-rich task management tool. [![Open-Source Software][oss]](https://github.com/abstractspoon/ToDoList)
+* [Torto](https://github.com/L-Chris/torto) - Native local-first e-book reader with two-page reading, search, highlights, translation, AI assistance, WebDAV sync, and no WebView. [![Open-Source Software][oss]](https://github.com/L-Chris/torto)
 * [WordWeb](https://wordweb.info/) - Comprehensive English dictionary.
 * [Saga Reader](https://github.com/sopaco/saga-reader) - A Blazing-Fast and Extremely-Lightweight Internet Reader driven by AI.Supports fetching of search engine information and RSS.
 * [EyeRest](https://github.com/necdetsanli/EyeRest) - A lightweight Windows tray application that gently reminds you to follow the 20–20–20 rule:


### PR DESCRIPTION
## What changed

Adds [Torto](https://github.com/L-Chris/torto) to the **Productivity** section.

## Why

Torto is an MIT-licensed, local-first ebook reader with a native Windows installer. It supports two-page reading, search, highlights, optional translation and AI assistance, direct WebDAV sync, and native book rendering without a WebView.

## Checks

- Added one alphabetically placed entry
- Used the list's open-source badge format
- Linked to the public source repository and current Windows release