### PR TITLE
Add Copy-on-Select to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ More information in CLAUDE.md and llms.txt.
 * [AutoHotkey](https://autohotkey.com/) - Automation scripting language for Windows. ![Open-Source Software](/assets/opensource.svg)
 * [Beetroot](https://max.nardit.com/beetroot) - Manages clipboard history with AI text transforms and OCR extraction.
 * [Cold Turkey](https://getcoldturkey.com) - Website blocker with strict enforcement mechanisms.
+* [Copy-on-Select](https://apps.microsoft.com/detail/9PCVRVR3QQKS) - Copies text to the clipboard the moment you select it with the mouse, system-wide including consoles. ![paid]
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.


### PR DESCRIPTION
Adds **Copy-on-Select** to the Productivity section, in alphabetical order (after Cold Turkey), following the `* [Name](link) - Description.` format with the `![paid]` badge.

```
* [Copy-on-Select](https://apps.microsoft.com/detail/9PCVRVR3QQKS) - Copies text to the clipboard the moment you select it with the mouse, system-wide including consoles. ![paid]
```

**What it is:** the Linux/X11 select-to-copy behaviour on Windows. Highlight text with the mouse and it is on the clipboard when you release the button — no Ctrl+C.

**Why it belongs on the list:** the entries people currently find for this behaviour are AutoClipX (its FileHippo installer is flagged by multiple antivirus engines as an adware bundler) and TXMouse (last updated around 2005, only reachable through the Internet Archive). This one is a signed Microsoft Store distribution, actively maintained, with no bundled software.

**What makes it different from the near-alternatives:**
- Works system-wide — Win32, UWP, editors, PDF readers **and consoles** (cmd, PowerShell, Windows Terminal). Browser extensions and Windows Terminal's own setting each only cover their own island.
- Reads the selection via Windows UI Automation, not keystroke hooking — it is not a keylogger.
- Fully local: no network access used or required.
- `Alt+C` toggles it off; graphic editors excluded by default so drag-selections don't spam the clipboard.
- One-time purchase ($4.99), no subscription, no ads, no telemetry. Requires Windows 10 1809+.

**Disclosure:** I'm the developer. Happy to adjust the wording, category or badge if you'd prefer it elsewhere — and to drop it entirely if you feel it doesn't clear the "awesome" bar.