### PR TITLE
Add Multi Instance for Claude Desktop to System Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [IrfanView](https://www.irfanview.com/) - Fast and compact image viewer and converter.
 * [LightBulb](https://github.com/Tyrrrz/LightBulb) - Adaptive screen brightness utility.
 * [LocalSend](https://localsend.org/) - Free, open-source and cross-platform app that allows you to securely share files and messages with nearby devices over your local network without needing an internet connection. [![Open-Source Software][oss]](https://github.com/localsend/localsend)
+* [Multi Instance for Claude Desktop](https://apps.microsoft.com/detail/9NG247TJ47P0) - Runs several isolated Claude Desktop instances side by side, each with its own account and settings.
 * [MultiDrive](https://multidrive.io/) - Free app to clone, erase, backup drives.
 * [neohtop](https://github.com/Abdenasser/neohtop) - Modern system monitor built with Svelte and Rust. ![Open-Source Software](/assets/opensource.svg) ![star]
 * [Nirsoft](https://www.nirsoft.net/utils/index.html) - Collection of utility softwares.


### PR DESCRIPTION
Adds **Multi Instance for Claude Desktop** to System Utilities, alphabetically before MultiDrive.

```
* [Multi Instance for Claude Desktop](https://apps.microsoft.com/detail/9NG247TJ47P0) - Runs several isolated Claude Desktop instances side by side, each with its own account and settings.
```

**What it solves:** Claude Desktop is a single-instance app — every copy points at the same user-data directory, so signing into a second window logs the first one out. This launches isolated instances (separate `--user-data-dir` from a portable copy), each with its own account, session, MCP servers and accent colour, and it survives Claude's auto-updates. Free, no ads, no in-app purchases.

**Traction:** roughly 3,000 installs a month from the Store, so there is a real audience for it rather than it being a proof of concept.

**Honest caveats**, so you can judge it fairly:
- It is **niche by definition** — only useful to people who run Claude Desktop. If you consider that too narrow for the list, close this and no hard feelings; I would rather the list stay good than get my entry in.
- Sign-in is manual once per instance, because Claude's `claude://` deep link is global. Documented up front on the listing.
- Windows 10/11 only.

**Disclosure:** I'm the developer. Separate PR from #241 per the contributing guidelines (one suggestion per PR). Happy to move it to a different section — "Local AI" was the other candidate, but that section is about running local models, which this isn't.