### PR TITLE
Add No Bloat PDF to Office Suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ More information in CLAUDE.md and llms.txt.
 * [LibreOffice](https://www.libreoffice.org/) - Handles complex document formatting and supports extensive file formats. [![Open-Source Software][oss]](https://www.libreoffice.org/about-us/source-code/) ![star]
 * [Microsoft Office](https://www.office.com) - Provides real-time collaboration and cloud integration across apps.
 * [NitroPDF](https://www.gonitro.com/pdf-reader) - Converts and edits PDFs with OCR capabilities.
+* [No Bloat PDF](https://www.nobloatpdf.com) - Opens PDFs instantly from a 4.6 MB install, with tabs, search, and page editing, and makes zero network calls. [![Open-Source Software][oss]](https://github.com/bgalvan1277/NoBloatPDF)
 * [OnlyOffice](https://www.onlyoffice.com/) - Enables document co-editing with version control. [![Open-Source Software][oss]](https://github.com/ONLYOFFICE/DesktopEditors)
 * [OpenOffice](https://www.openoffice.org/) - Focuses on stability and legacy format support. [![Open-Source Software][oss]](https://openoffice.apache.org/source.html)
 * [Sumatra PDF](https://www.sumatrapdfreader.org/free-pdf-reader.html) - Opens documents instantly with minimal memory usage. [![Open-Source Software][oss]](https://github.com/sumatrapdfreader/sumatrapdf)


### PR DESCRIPTION
Adds [No Bloat PDF](https://www.nobloatpdf.com), a free MIT-licensed PDF viewer for Windows and macOS.

- 4.6 MB installer, no admin rights, opens documents instantly
- Tabs, full text search, bookmarks, page editing, annotations, signatures, form filling
- Makes zero network calls, so it works identically offline. No telemetry, accounts, ads, or paid tier
- Rendered by Mozilla pdf.js in a Tauri shell rather than a bundled browser, which is where the size comes from
- Installer is signed with a Microsoft-verified publisher identity; macOS builds are notarized
- Source: https://github.com/bgalvan1277/NoBloatPDF
- Also installable with `winget install nobloatpdf`

Placed alphabetically between NitroPDF and OnlyOffice, in the same format as neighbouring entries, with the open-source badge. Single line added, no other changes.

Disclosure: I am submitting on behalf of the developer.