### PR TITLE
Add Vanpelt Studio to Video Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [ScreenToGif](https://www.screentogif.com/) - Records screen areas and saves as GIF or video. [![Open-Source Software][oss]](https://github.com/NickeManarin/ScreenToGif/)
 * [Shotcut](https://www.shotcut.org/download/) - Video editor with native timeline filtering. [![Open-Source Software][oss]](https://github.com/mltframework/shotcut)
 * [Shutter Encoder](https://www.shutterencoder.com/) - Converts between hundreds of media formats with processing options.
+* [Vanpelt Studio](https://vanpelt.studio) - Plans long-form YouTube videos and verifies footage against the story before editing. ![paid]
 * [VLC](https://www.videolan.org/vlc/index.html) - Plays damaged/incomplete media files and network streams. [![Open-Source Software][oss]](https://github.com/videolan/vlc)
 
 ## Virtualization


### PR DESCRIPTION
Adds [Vanpelt Studio](https://vanpelt.studio) to **Video Utilities**, alphabetically before VLC.

It's a local-first desktop app (Windows + macOS) for solo YouTube creators making long-form video: plan the story (beat sheet, script, shot list), ingest footage with on-device Whisper transcription and a visual index, and get a structural check of the footage against the plan before editing starts. It never uploads and never cuts footage — it's the pre-edit layer, not an editor. Marked ![paid] (currently in beta).

Disclosure: I'm the maker — happy to adjust wording or placement.