### PR TITLE
Add FullscreenZoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [HWMonitor](https://www.cpuid.com/softwares/hwmonitor.html) - Hardware monitoring for temperatures, voltages, and fan speeds.
 * [IrfanView](https://www.irfanview.com/) - Fast and compact image viewer and converter.
 * [LightBulb](https://github.com/Tyrrrz/LightBulb) - Adaptive screen brightness utility.
+* [FullscreenZoom](https://github.com/kaikimax/better-magnifier) - Lightweight, smooth, cursor-following fullscreen zoom and pan for Windows, controlled by hotkeys.
 * [LocalSend](https://localsend.org/) - Free, open-source and cross-platform app that allows you to securely share files and messages with nearby devices over your local network without needing an internet connection. [![Open-Source Software][oss]](https://github.com/localsend/localsend)
 * [MultiDrive](https://multidrive.io/) - Free app to clone, erase, backup drives.
 * [neohtop](https://github.com/Abdenasser/neohtop) - Modern system monitor built with Svelte and Rust. ![Open-Source Software](/assets/opensource.svg) ![star]


### PR DESCRIPTION
Adds FullscreenZoom, a lightweight fullscreen zoom/pan tool for Windows — tray-resident, controlled entirely by one-handed hotkeys (Alt+Z/R/Q, Alt+Up/Down), no config panel or drawing/recording features, just smooth cursor-following zoom.

Distinct from the existing entries in this category:
- vs. magnify-snap: that's a panel-driven tool with fixed preset zoom levels; this is continuous zoom/pan via hotkeys, no panel.
- vs. ZoomIt: that's a full presentation toolkit (zoom + drawing + screen recording + OCR + timers); this does zoom only, with a smaller footprint for people who don't need the rest.