### PR TITLE
Add ImeModePersistence to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ More information in CLAUDE.md and llms.txt.
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.
+* [ImeModePersistence](https://github.com/mangokingTW/ImeModePersistence) - Keeps the IME conversion mode consistent across windows and binds a chosen input language per application, even for anti-cheat fullscreen games. [![Open-Source Software][oss]](https://github.com/mangokingTW/ImeModePersistence)
 * [Kaas](https://github.com/0xfrankz/Kaas) - Privacy-focused LLM client for multiple AI services. ![Open-Source Software](/assets/opensource.svg)
 * [KatMouse](https://www.ehiti.de/katmouse/) - Universal scrolling utility for Windows.
 * [Keywiz](https://mularahul.github.io/keyviz/) - Real-time keystroke visualization tool. [![Open-Source Software][oss]](https://github.com/mulaRahul/keyviz)


### PR DESCRIPTION
Adds [ImeModePersistence](https://github.com/mangokingTW/ImeModePersistence) under **Productivity** (alphabetical, after File Juggler).

An open-source (MIT) Windows tray utility that keeps the IME conversion mode (Chinese/Japanese/Korean vs. alphanumeric) consistent as you switch windows, and binds chosen applications to a fixed input language — including anti-cheat fullscreen games (e.g. Helldivers 2) that ignore the normal per-app input settings. Native C++20, unit-tested, with build provenance and an OpenSSF Scorecard; also on Scoop and submitted to winget/Chocolatey.

- Uses the reference-style `[oss]` open-source badge.
- Single PR, alphabetical order, title-cased.