### PR TITLE
Add Mongrel to Databases Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ More information in CLAUDE.md and llms.txt.
 * [DB Browser for SQLite](https://sqlitebrowser.org/) - Visual tool for creating and editing SQLite database files. ![Open-Source Software](/assets/opensource.svg)
 * [pgAdmin](https://www.pgadmin.org/) - Feature-rich, open-source administration and development platform for PostgreSQL. [![Open-Source Software][oss]](https://github.com/pgadmin-org/pgadmin4)
 * [DBeaver](https://dbeaver.io/) - Free and open-source database management tool. [![Open-Source Software][oss]](https://github.com/dbeaver/dbeaver)
+* [Mongrel](https://www.visorcraft.com/) - Desktop workbench for 30+ database engines, with SSH terminals, SFTP, Docker, Kubernetes, and an API client.
 
 ## Developer Utilities
 


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/) to Databases Clients, after DBeaver.

Mongrel is a Windows desktop database workbench for 30+ engines, with SSH terminals, SFTP, Docker, Kubernetes, and an API client. MSI and NSIS installers are published for x64 and arm64.

Linked to the product homepage (proprietary; no public app source).