### PR TITLE
Add StarWhisper to Local AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ More information in CLAUDE.md and llms.txt.
 * [Jan](https://jan.ai) - Offline private AI assistant with CPU/GPU support. [![Open-Source Software][oss]](https://github.com/janhq/jan)
 * [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs with a user-friendly interface.
 * [Ollama](https://ollama.com/) - Get up and running with large language models locally via command line. [![Open-Source Software][oss]](https://github.com/ollama/ollama)
+* [StarWhisper](https://starwhisper.ai) - Offline voice-to-text dictation using a local Whisper model, types into any app via a global hotkey.
 
 ## Networking
 


### PR DESCRIPTION
Adds StarWhisper to the Local AI category.

It runs a Whisper model locally via whisper.cpp and inserts the transcript into
whichever application has focus, triggered by a global hotkey. Transcription happens
entirely on the device, so it works with no network connection.

Placed last in Local AI to keep the category alphabetical (Jan, LM Studio, Ollama,
StarWhisper). No open-source badge, since it is closed-source, consistent with the
LM Studio entry.

Disclosure: I am the developer.