### PR TITLE
Add DuckDeck to the list of audio software

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ More information in CLAUDE.md and llms.txt.
 * [AudioNodes](https://audionodes.com/) - Produces music with mixing, effects, MIDI and synthesis.
 * [Cider](https://cider.sh/) - Streams Apple Music. ![paid](/assets/paid.svg)
 * [Dopamine](https://digimezzo.github.io/site/) - Plays and organizes music. [![Open-Source Software][oss]](https://github.com/digimezzo/dopamine)
+* [DuckDeck](https://duckdeck.app/) - Global hotkeys for your music volume that work inside fullscreen games, with automatic ducking when someone talks in Discord. ![paid]
 * [FL Studio](https://www.image-line.com/) - Complete digital audio workstation (DAW) for composing, arranging, recording, and mastering. ![paid]
 * [FlexASIO](https://flexasio.com/) - A universal ASIO driver that delivers low-latency, high-quality sound. [![Open-Source Software][oss]](https://github.com/dechamps/FlexASIO)
 * [Foobar2000](https://www.foobar2000.org/) - Plays audio with customization options.


### PR DESCRIPTION
DuckDeck lets you control your music volume with global hotkeys that work inside fullscreen games, without touching your game, voice chat or system audio. Pro adds automatic ducking when someone speaks in Discord, a separate volume level per game, and a click-through on-screen overlay.