### PR TITLE
Add DBTool to Databases Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ More information in CLAUDE.md and llms.txt.
 * [DB Browser for SQLite](https://sqlitebrowser.org/) - Visual tool for creating and editing SQLite database files. ![Open-Source Software](/assets/opensource.svg)
 * [pgAdmin](https://www.pgadmin.org/) - Feature-rich, open-source administration and development platform for PostgreSQL. [![Open-Source Software][oss]](https://github.com/pgadmin-org/pgadmin4)
 * [DBeaver](https://dbeaver.io/) - Free and open-source database management tool. [![Open-Source Software][oss]](https://github.com/dbeaver/dbeaver)
+* [DBTool](https://codemake.co/software) - Desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and SQL Server, with server-side pagination, a visual join builder and ER diagrams. [![Open-Source Software][oss]](https://github.com/achi777/db-tool)
 
 ## Developer Utilities
 


### PR DESCRIPTION
Adds **DBTool** to Databases Clients.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client covering PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server behind one interface. Windows build is an NSIS installer (per-user, no admin) or a single portable `.exe`.

Relative to the clients already in the section: it covers Oracle and SQL Server, which the free options here mostly do not, and adds true server-side pagination (ordering, counting and paging happen in the database rather than the client), a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with a live DDL preview, and editable ER diagrams. Passwords go to Windows DPAPI; no telemetry and no account.

Tagged with the OSS badge to match the other open-source entries.

One thing worth stating plainly: the Windows build is currently unsigned, so SmartScreen warns on first run. `SHA256SUMS.txt` is published with every release.

I am the author of this project.
