### PR TITLE
Add NetFix (networking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ More information in CLAUDE.md and llms.txt.
 
 * [Fiddler](https://www.telerik.com/fiddler) - Web debugging proxy.
 * [Nmap](https://nmap.org/) - A free, open-source network scanner used for discovering hosts, services, and vulnerabilities on computer networks through advanced port scanning and OS detection techniques. [![Open-Source Software][oss]](https://github.com/nmap/nmap)
+* [NetFix](https://github.com/cruzamilcars/netfix) - Desktop app to diagnose, repair and monitor network connections: IP/DNS/Winsock reset, per-app live traffic, browser history inspection and QoS. [![Open-Source Software][oss]](https://github.com/cruzamilcars/netfix)
 * [Sniffnet](https://sniffnet.net/) - Network monitoring tool to help you easily keep track of your Internet traffic. [![Open-Source Software][oss]](https://github.com/GyulyVGC/sniffnet)
 * [Wireshark](https://www.wireshark.org/) - Network protocol analyzer. [![Open-Source Software][oss]](https://www.wireshark.org/docs/wsdg_html_chunked/ChIntroDevelopment.html)
 


### PR DESCRIPTION
## What

Adds **[NetFix](https://github.com/cruzamilcars/netfix)** to the **Networking** section, in alphabetical order (after Nmap).

## About the tool

NetFix is an open-source (MIT) desktop app to diagnose, repair and monitor network connections on Windows/macOS/Linux: IP/DNS/Winsock repair with per-OS command plans, live per-app traffic monitor, DNS cache and browser history inspection (read-only SQLite copies), and QoS policies. Built with Rust + Tauri 2, ~6 MB portable binary, zero runtime dependencies, 100% local (no telemetry).

- Versioned releases with installers + portable binaries (v0.2.3)
- Unit tests, CHANGELOG, bilingual README with screenshot
- Actively maintained

## Checklist

- [x] Not a duplicate (no network repair/diagnostic suite present)
- [x] Alphabetical order respected
- [x] Format matches existing entries (\* [Name](link) - Description.\ + OSS badge)
- [x] No trailing whitespace
- [x] Open source (MIT) with public repo