### PR TITLE
Add Talkdedsec Visual to Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ More information in CLAUDE.md and llms.txt.
 * [Rainmeter](https://www.rainmeter.net/) - Displays customizable skins and widgets. [![Open-Source Software][oss]](https://github.com/rainmeter/rainmeter)
 * [Shell](https://nilesoft.org) - Powerful, free, open source context menu manager ![oss]
 * [Sucrose Wallpaper Engine](https://github.com/Taiizor/Sucrose) - A live wallpaper app, a free and opensource alternative to Wallpaper Engine. [![Open-Source Software][oss]](https://github.com/Taiizor/Sucrose)
+* [Talkdedsec Visual](https://github.com/Talkdedsec1/tlk-visual) - Adjusts screen brightness, contrast, gamma and colour temperature in real time. [![Open-Source Software][oss]](https://github.com/Talkdedsec1/tlk-visual)
 * [Themia](https://themia.app) - Displays transparent, customizable widgets on your desktop.
 * [TranslucentTB](https://github.com/TranslucentTB/TranslucentTB) - Makes taskbar transparent. ![Open-Source Software](/assets/opensource.svg)
 * [Wallpaper Engine](https://www.wallpaperengine.io/) - Animated wallpapers for you dekstop. ![paid]


### PR DESCRIPTION
Adds [Talkdedsec Visual](https://github.com/Talkdedsec1/tlk-visual) to the Customization section.

It writes brightness, contrast, gamma, colour temperature and a night vision mode straight to the display gamma ramp, so the change applies system-wide and in fullscreen games without an overlay. Single exe, no driver, no injection, no admin rights, nothing resident. Written in Rust with a Slint UI, GPL-3.0.

Closest existing entries are the monitor and taskbar tweakers already in this section; nothing here currently covers colour and gamma control.

One entry, inserted alphabetically between Sucrose Wallpaper Engine and Themia, formatting and oss badge match the surrounding lines.