### PR TITLE
Add TLK Pass to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [NetLimiter](https://www.netlimiter.com) - Internet traffic control and monitoring tool.
 * [SpyBot](https://www.safer-networking.org/) - Malware and spyware detection and removal.
 * [System Explorer](https://systemexplorer.net) - Enhanced task manager with advanced system monitoring.
-* [TLK Pass](https://talkdedsec1.github.io/tlk-pass/) - Generates passwords and passphrases offline in a single HTML file. [![Open-Source Software][oss]](https://github.com/Talkdedsec1/tlk-pass)
+* [TLK Pass](https://talkdedsec.github.io/tlk-pass/) - Generates passwords and passphrases offline in a single HTML file. [![Open-Source Software][oss]](https://github.com/Talkdedsec/tlk-pass)
 * [Tor Project](https://www.torproject.org/) - Anonymous communication network. [![Open-Source Software][oss]](https://github.com/TheTorProject)
 * [UnChecky](https://unchecky.com/) - Automated unwanted software offer prevention.
 * [VeraCrypt](https://www.veracrypt.fr/en/Home.html) - Disk encryption software for multiple platforms. [![Open-Source Software][oss]](https://www.veracrypt.fr/code/VeraCrypt/)

--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [NetLimiter](https://www.netlimiter.com) - Internet traffic control and monitoring tool.
 * [SpyBot](https://www.safer-networking.org/) - Malware and spyware detection and removal.
 * [System Explorer](https://systemexplorer.net) - Enhanced task manager with advanced system monitoring.
+* [TLK Pass](https://talkdedsec1.github.io/tlk-pass/) - Generates passwords and passphrases offline in a single HTML file. [![Open-Source Software][oss]](https://github.com/Talkdedsec1/tlk-pass)
 * [Tor Project](https://www.torproject.org/) - Anonymous communication network. [![Open-Source Software][oss]](https://github.com/TheTorProject)
 * [UnChecky](https://unchecky.com/) - Automated unwanted software offer prevention.
 * [VeraCrypt](https://www.veracrypt.fr/en/Home.html) - Disk encryption software for multiple platforms. [![Open-Source Software][oss]](https://www.veracrypt.fr/code/VeraCrypt/)


### PR DESCRIPTION
Adds [TLK Pass](https://talkdedsec.github.io/tlk-pass/) to the Security section.

It is a password and passphrase generator that is one HTML file. No install, no dependencies, no network requests at all - the page works after saving it to disk and opening it offline, and entropy comes from the Web Crypto API rather than Math.random. The link above is the live page; the same file is in the repo and can be audited in one sitting.

MIT licensed. Listed under Security rather than Password Managers since it generates credentials and stores nothing.

One entry, inserted alphabetically between System Explorer and Tor Project, formatting and oss badge match the surrounding lines.
