### PR TITLE
Add Noctis to Proxy and VPN Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [Algo](https://github.com/trailofbits/algo) - Personal IPSEC VPN in the cloud.
 * [Cloudflare WARP](https://1.1.1.1) - Fast, free VPN and DNS.
 * [Mullvad VPN](https://mullvad.net) - No-logs Sweden VPN service.
+* [Noctis](https://noctis.c0nn3ct.info/) - Browser-only proxy for Chrome over VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC or WireGuard.
 * [ProtonVPN](https://protonvpn.com/) - High-speed Swiss VPN that safeguards your privacy. ![star]
 * [Tailscale](https://tailscale.com/) - Zero config VPN for building secure networks. ![star]
 * [Twingate](https://www.twingate.com/) - Modern zero trust network access solution.


### PR DESCRIPTION
Noctis routes browser traffic through your own proxy server and leaves the rest of the system alone. A native helper runs a local sing-box, Xray or mihomo core, so the extension speaks VLESS and VLESS Reality, VMess, Trojan, Shadowsocks, Hysteria2, TUIC, WireGuard, AnyTLS and ShadowTLS. Per-host rules decide whether a request takes the proxy or goes direct.

- Site: https://noctis.c0nn3ct.info
- Web Store: https://chromewebstore.google.com/detail/noctis/nmhobajopepdpihahepaddpdifdcenpn
- Helper source, MIT: https://github.com/c0nn3ct-info/noctis
- Free, no account. The Windows helper installs from a PowerShell one-liner.

Added alphabetically under Proxy and VPN Tools, between Mullvad VPN and ProtonVPN. Title-cased, one suggestion in this pull request, duplicates checked.

Disclosure: I wrote Noctis.
