### PR TITLE
Add SpeakType to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ More information in CLAUDE.md and llms.txt.
 * [Nani Translate](https://nani.now) - Fast AI translator that explains and refines your phrasing.
 * [Ninite](https://ninite.com/) - Streamlined software installation utility.
 * [PhraseVault](https://phrasevault.app/) - Expands text snippets with fuzzy search, usage-based prioritization, and local-only data storage. ![paid]
+* [SpeakType](https://github.com/wookat/speaktype) - Hold-to-talk voice typing into any app with offline recognition and vocabulary learning from your edits. ![Open-Source Software](/assets/opensource.svg)
 * [STranslate](https://github.com/ZGGSONG/STranslate) - A ready-to-go translation ocr tool developed with WPF ![Open-Source Software](/assets/opensource.svg)
 * [Super Productivity](https://super-productivity.com/) - Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration. [![Open-Source Software][oss]](https://github.com/johannesjo/super-productivity)
 * [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine. ![paid]


### PR DESCRIPTION
Adds [SpeakType](https://github.com/wookat/speaktype) to Productivity (alphabetical order, before STranslate).

SpeakType is an MIT-licensed voice-typing app for Windows: hold a hotkey, speak, and the recognized text is typed into whatever app has focus. Recognition runs fully offline by default (SenseVoice / Parakeet / whisper.cpp, one-click model download), it learns vocabulary corrections from your later edits, and it can use your phone as a remote microphone. Not a wrapper around a cloud service - all data stays local unless you opt into a cloud provider.