### PR TITLE
Add iScribby to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [Capter](https://github.com/decipher3114/Capter) - A simple screenshot tool made in rust. ![oss]
 * [Flameshot](https://flameshot.org/) - Customizable screenshot tool with an easy-to-use interface and built-in editor. [![Open-Source Software][oss]](https://github.com/flameshot-org/flameshot)
 * [Greenshot](https://getgreenshot.org/) - Greenshot is a light-weight screenshot software tool for Windows. [![Open-Source Software][oss]](https://github.com/greenshot/greenshot)
+* [iScribby](https://iscribby.com/) - A neat little tool that allows you to draw and copy things directly on your screen from anywhere, without interrupting your workflow.
 * [Lightshot](https://app.prntscr.com/en/index.html) - A fast and intuitive screenshot tool that allows capturing and editing images instantly.
 * [ShareX](https://getsharex.com/) - Powerful, open-source screenshot and screen recording tool with advanced editing options. [![Open-Source Software][oss]](https://github.com/ShareX/ShareX) ![star]
 


### PR DESCRIPTION
A proposal to add iScribby into the list of apps.

**Quick summary:**
A Windows desktop application that let's you draw directly on your screen from anywhere (full-screen apps too), while being as unobtrusive as possible - it runs in the background until you need it and it doesn't steal focus away from your apps if you enable the mode for drawing.

**Website:**
https://iscribby.com/