### PR TITLE
Add Codex Quota Overlay to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ More information in CLAUDE.md and llms.txt.
 ## Developer Utilities
 
 * [Cacher](https://www.cacher.io/) - Syncs and organizes code snippets with Gist integration and IDE plugins.
+* [Codex Quota Overlay](https://github.com/cpys/codex-quota-overlay) - Independent Windows tray utility that displays Codex quota limits, reset countdowns, pace and forecast context, and a local quota center. [![Open-Source Software][oss]](https://github.com/cpys/codex-quota-overlay)
 * [Git](https://git-scm.com) - Git a distributed version control system that can manage source code reposistories including versioning, syncing, and cloning. [![Open-Source Software][oss]](https://github.com/git/git)
 * [Kunobi](https://kunobi.ninja) - Kubernetes management app written in Rust with MCP integration.
 * [Mamp](https://www.mamp.info/en/) - Runs Apache, MySQL and PHP stack locally.


### PR DESCRIPTION
Adds one factual entry under Developer Utilities.\n\nCodex Quota Overlay is an independent Windows tray utility that displays Codex quota limits, reset countdowns, pace and forecast context, and a local Quota Center. The project is MIT-licensed, targets Windows 10/11 x64, and keeps quota data local.\n\nMaintainer disclosure: I maintain cpys/codex-quota-overlay. This is an independent community project and is not affiliated with, endorsed by, or supported by OpenAI. No paid placement is requested.