### PR TITLE
Add AI Novel Writer to Text Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 
 ## Text Editors
 
+* [AI Novel Writer](https://github.com/EthanYoQ/AI-Novel-Writer) - Desktop workspace for planning, drafting, reviewing, and revising long-form fiction with optional Ollama support. [![Open-Source Software][oss]](https://github.com/EthanYoQ/AI-Novel-Writer)
 * [GVim](https://www.vim.org/download.php#pc) - Highly configurable text editor optimized for efficiency. [![Open-Source Software][oss]](https://github.com/vim/vim-win32-installer/releases/tag/v9.1.0679)
 * [Inkwell](https://github.com/4worlds4w-svg/inkwell) - Portable Markdown editor with split view, live preview, themes, focus mode, and diff viewer. Built with Tauri v2.
 * [LazyVim](https://www.lazyvim.org/) - Customizable Neovim configuration framework. [![Open-Source Software][oss]](https://github.com/LazyVim/LazyVim)


### PR DESCRIPTION
Adds AI Novel Writer as an open-source Windows desktop writing workspace. The entry is placed alphabetically in Text Editors and uses the list existing one-line format. The project has a current Windows x64 installer, public source, GPL-3.0 license, and active releases.