### PR TITLE
Add QuickImageViewer to Graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ More information in CLAUDE.md and llms.txt.
 * [Oculante](https://github.com/woelper/oculante) - Lightweight, fast and simple image viewer written in rust. ![Open-Source Software](/assets/opensource.svg) ![star]
 * [Paint.NET](https://www.getpaint.net/index.html) - Feature-rich image editing tool.
 * [pngquant](https://pngquant.org/) - Command-line PNG compression utility.
+* [QuickImageViewer](https://icyhoty2k.github.io/QuickImageViewer/) - Portable image viewer with an Android companion that turns a spare phone into a photo frame. [![Open-Source Software][oss]](https://github.com/icyhoty2k/QuickImageViewer)
 
 ## IDEs
 


### PR DESCRIPTION
Adds QuickImageViewer to **Graphics**, in alphabetical order after pngquant.

**What it is:** a free, portable image viewer for Windows 10 and 11 — a single 9.7 MB executable, no installer, no ads, no telemetry, AGPLv3. It opens HEIC, AVIF, JPEG XL, WebP, SVG, OpenEXR and camera RAW, renders through Direct2D with a GPU bitmap cache, and has 230 keyboard shortcuts.

**Why it earns a line rather than being another viewer:** it has a free Android companion app that turns a spare phone or tablet into a remote control, a second screen, or a **photo frame the PC drives** over your own network — no cloud, no account, no third-party server. Oculante is already listed and is a fine viewer; this is the only entry that does the phone half.

- Site: https://icyhoty2k.github.io/QuickImageViewer/
- Source: https://github.com/icyhoty2k/QuickImageViewer
- Android app: https://play.google.com/store/apps/details?id=net.icyhoty2k.qivremote

Checked against CONTRIBUTING: not a duplicate, one suggestion in this PR, alphabetical within the existing category, `* [Name](link)` format with the `[oss]` badge, no trailing whitespace, no new category.
