### PR TITLE
Add Alcove to Customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ More information in CLAUDE.md and llms.txt.
 ## Customization
 
 * [7+ Taskbar Tweaker](https://rammichael.com/7-taskbar-tweaker) - Modifies Windows taskbar behavior.
+* [Alcove](https://cromis.org/alcove/) - Replaces the desktop icon grid with named drawers that take their colour from your wallpaper. [![Open-Source Software][oss]](https://github.com/izkac/alcove)
 * [OpenShell](https://github.com/Open-Shell/Open-Shell-Menu) - Restores traditional Start Menu interface. ![Open-Source Software](/assets/opensource.svg)
 * [EarTrumpet](https://eartrumpet.app/) - Controls volume per application. [![Open-Source Software][oss]](https://github.com/File-New-Project/EarTrumpet)
 * [FluentFlyout](https://fluentflyout.com/) - Displays media controls, lock key status and taskbar widgets in native-looking Fluent 2 flyouts. [![Open-Source Software][oss]](https://github.com/unchihugo/FluentFlyout)


### PR DESCRIPTION
Adds [Alcove](https://cromis.org/alcove/) under Customization, in alphabetical order.

Alcove is a Windows desktop organizer: it replaces Explorer's loose grid of desktop icons with named drawers that open one at a time and spread into a canvas when they get large, and it reads your wallpaper to tint its surfaces to match. It reads the real files on your Desktop and opens them with the real Windows shell, so nothing is copied or moved, and `Ctrl+Shift+F12` hands the desktop back to Explorer at any point.

MIT, Rust and Tauri, no account and no telemetry. Source: https://github.com/izkac/alcove

One thing worth disclosing up front: the installer is not yet Authenticode-signed, so SmartScreen warns on first run. The download page says so plainly, publishes the installer's SHA-256, and ships a build attestation you can verify against the source. Happy to hold off until that is sorted if the list would rather.