### PR TITLE
Add MultiTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [FluentTerminal](https://github.com/felixse/FluentTerminal) - UWP-based modern terminal emulator.
 * [Kitty](https://www.9bis.net/kitty/) - Enhanced PuTTY with additional features.
 * [MobaXterm](https://mobaxterm.mobatek.net/) - Enhanced terminal with X server and SSH client.
+* [MultiTerm](https://github.com/idk-arsh/multiterm) - Multi-pane terminal with workspaces that remember folders and startup commands, plus broadcast typing. ![Open-Source Software](/assets/opensource.svg)
 * [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) - SSH and telnet client.
 * [Tabby](https://tabby.sh/) - Configurable terminal built on web technologies. [![Open-Source Software][oss]](https://github.com/Eugeny/tabby)
 * [Termius](https://termius.com) - Modern SSH Client built for productivity and collaboration.


### PR DESCRIPTION
Adds MultiTerm to the Terminal section, in alphabetical order.

MultiTerm is an MIT-licensed multi-pane terminal for Windows 10 and 11. Real ConPTY shells (cmd, PowerShell, pwsh, Git Bash, WSL) side by side; workspaces that reopen a project's folders with a startup command per folder; broadcast typing that sends one keystroke to every pane. Python and Tk, no Electron, single 13 MB portable exe.

Repo: https://github.com/idk-arsh/multiterm
