### PR TITLE
Add ScribeDrop to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ More information in CLAUDE.md and llms.txt.
 * [Ninite](https://ninite.com/) - Streamlined software installation utility.
 * [OpenHabitTracker](https://openhabittracker.net) - Take notes, plan tasks, and track habits. [![Open-Source Software][oss]](https://github.com/Jinjinov/OpenHabitTracker)
 * [PhraseVault](https://phrasevault.app/) - Expands text snippets with fuzzy search, usage-based prioritization, and local-only data storage. ![paid]
+* [ScribeDrop](https://github.com/DJsluxx/scribedrop) - Drag-and-drop Whisper GUI that transcribes audio/video to TXT/SRT/VTT fully offline. [![Open-Source Software][oss]](https://github.com/DJsluxx/scribedrop)
 * [STranslate](https://github.com/ZGGSONG/STranslate) - A ready-to-go translation ocr tool developed with WPF ![Open-Source Software](/assets/opensource.svg)
 * [Super Productivity](https://super-productivity.com/) - Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration. [![Open-Source Software][oss]](https://github.com/johannesjo/super-productivity)
 * [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine. ![paid]


### PR DESCRIPTION
Adds ScribeDrop, a free, MIT-licensed, offline Whisper transcription GUI for Windows (drag in audio/video, get TXT/SRT/VTT back, no cloud upload).

**Disclosure:** I'm the project's maintainer/author, not a neutral third party. Filing this myself since it fits the existing Productivity section alongside similar local speech-to-text tools (TypeWhisper).

Repo: https://github.com/DJsluxx/scribedrop (MIT license)