### PR TITLE
Add Planim Time to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ More information in CLAUDE.md and llms.txt.
 * [Ninite](https://ninite.com/) - Streamlined software installation utility.
 * [OpenHabitTracker](https://openhabittracker.net) - Take notes, plan tasks, and track habits. [![Open-Source Software][oss]](https://github.com/Jinjinov/OpenHabitTracker)
 * [PhraseVault](https://phrasevault.app/) - Expands text snippets with fuzzy search, usage-based prioritization, and local-only data storage. ![paid]
+* [Planim Time](https://time.planim.app/jira) - Tray time tracker for Jira with a one-click timer, two-way worklog sync, and offline-first local storage.
 * [STranslate](https://github.com/ZGGSONG/STranslate) - A ready-to-go translation ocr tool developed with WPF ![Open-Source Software](/assets/opensource.svg)
 * [Super Productivity](https://super-productivity.com/) - Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration. [![Open-Source Software][oss]](https://github.com/johannesjo/super-productivity)
 * [talat](https://talat.app) - On-device meeting recording and transcription that keeps mic and system audio on your machine. ![paid]


### PR DESCRIPTION
Adds Planim Time to Productivity, in alphabetical order between PhraseVault and STranslate.

Tray time tracker for Jira (Windows, macOS, Linux): start a timer on an issue, and the entry is pushed to Jira as a regular worklog under your own account. Two-way sync pulls existing worklogs back, everything is stored locally, works offline. Tauri 2 with a Rust core, ~6 MB installer. Free tier has no limits on tracking or sync; Pro adds auto-push, calendar view, idle detection and reports, so no paid badge added. I'm the developer.
