### PR TITLE
Add OrcaReplay to Developer Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ More information in CLAUDE.md and llms.txt.
 * [Git](https://git-scm.com) - Git a distributed version control system that can manage source code reposistories including versioning, syncing, and cloning. [![Open-Source Software][oss]](https://github.com/git/git)
 * [Kunobi](https://kunobi.ninja) - Kubernetes management app written in Rust with MCP integration.
 * [Mamp](https://www.mamp.info/en/) - Runs Apache, MySQL and PHP stack locally.
+* [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) - Records a coding agent below the harness and replays the run offline with the network off, or forks it onto a different model. ![Open-Source Software](/assets/opensource.svg)
 * [Pieces](https://pieces.app/) - Uses AI to help capture, organize and reuse code snippets and dev resources.
 * [Velocity](https://velocity.silverlakesoftware.com/) - Browses and searches API documentation without internet connection.
 * [Xampp](https://www.apachefriends.org/index.html) - Bundles Apache, MariaDB, PHP and Perl for local development.


### PR DESCRIPTION
Adds OrcaReplay to **Developer Utilities**, in alphabetical position.

**What it does.** Records a coding agent (Claude Code, Codex, opencode, Qwen Code, Cursor and others) below the harness, at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all land on one timeline. The run then replays offline with the network off, or forks from a chosen checkpoint onto a different model.

**On the "vibecoded slop" caution up front** — the fair thing is to give you what you'd check anyway rather than make you dig:

- Apache-2.0, free, no account and no hosted service. Installs with `npm i -g orcareplay` (Node 20+).
- 12 packages published to npm with sigstore provenance; `orca doctor` reports 11 checks with 0 failures on Windows, which is where I develop it.
- Windows specifics are handled deliberately, not incidentally: the PATH shim is a `.cmd`/`.ps1` pair, and the loopback proxy binds `127.0.0.1` and releases the port.
- There is a written validation record of a real bug fix recorded, replayed offline end to end, and forked from a checkpoint — [docs/validation.md](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md).
- The honest counterweight: the repository is nine days old with 150 stars. If your bar for "awesome" includes a track record, this does not have one yet, and that is a reasonable reason to hold it.

**Guidelines followed:** searched for duplicates first, one item in one PR, `* [Name](link) - Description.` with title casing, alphabetical within the category, no trailing whitespace, open-source badge included as the section does.
