### PR TITLE
Mark Beetroot as open-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ More information in CLAUDE.md and llms.txt.
 ## Productivity
 
 * [AutoHotkey](https://autohotkey.com/) - Automation scripting language for Windows. ![Open-Source Software](/assets/opensource.svg)
-* [Beetroot](https://max.nardit.com/beetroot) - Manages clipboard history with AI text transforms and OCR extraction.
+* [Beetroot](https://max.nardit.com/beetroot) - Manages clipboard history with AI text transforms and OCR extraction. [![Open-Source Software][oss]](https://github.com/mnardit/beetroot-releases)
 * [Cold Turkey](https://getcoldturkey.com) - Website blocker with strict enforcement mechanisms.
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.


### PR DESCRIPTION
Beetroot is now open source (Apache-2.0). Adding the `[oss]` marker (linked to the source repo) to my existing Productivity entry. Source: https://github.com/mnardit/beetroot-releases