### PR TITLE
Add Jarvis to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ More information in CLAUDE.md and llms.txt.
 * [Easy Window Switcher](https://neosmart.net/EasySwitch/) - Fast application instance switcher.
 * [f.lux](https://stereopsis.com/flux/) - Automatic screen color temperature adjustment.
 * [File Juggler](https://www.filejuggler.com/) - Automated file organization with smart actions and PDF parsing.
+* [Jarvis](https://github.com/RizN91/jarvis) - Open-source voice dictation and AI assistant for Windows: hold a button, speak, and your words are typed into whichever app has focus. [![Open-Source Software][oss]](https://github.com/RizN91/jarvis)
 * [Kaas](https://github.com/0xfrankz/Kaas) - Privacy-focused LLM client for multiple AI services. ![Open-Source Software](/assets/opensource.svg)
 * [KatMouse](https://www.ehiti.de/katmouse/) - Universal scrolling utility for Windows.
 * [Keywiz](https://mularahul.github.io/keyviz/) - Real-time keystroke visualization tool. [![Open-Source Software][oss]](https://github.com/mulaRahul/keyviz)


### PR DESCRIPTION
Adds [Jarvis](https://github.com/RizN91/jarvis) to **Productivity**.

Jarvis is an open-source (MIT) Windows tray app for voice dictation and voice conversations: hold a mouse side button (or tap a hotkey), speak, and the text is typed at the cursor in whichever app has focus. It also runs a voice conversation with a configurable assistant, ships local wake words, a non-activating status pill, and 15 UI languages. No subscription — you bring your own API key, which is stored in Windows Credential Manager, never in a file.

Checked against CONTRIBUTING.md:

- [x] Alphabetical within the category (after File Juggler, before Kaas)
- [x] `* [Name](link) - Description.` format using the existing `[oss]: /assets/opensource.svg` reference
- [x] One suggestion, individual PR
- [x] Not a duplicate — TypeWhisper is the only adjacent entry, and this is a different product (cloud engines, voice conversation, wake words)

Repo: https://github.com/RizN91/jarvis · 88-second demo: https://rizn91.github.io/jarvis/#demo