### PR TITLE
Add Quillite Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 sec
 * [Neovim](https://neovim.io/) - Modern, extensible terminal-based editor. [![Open-Source Software][oss]](https://github.com/neovim/neovim)
 * [Notepad++](https://notepad-plus-plus.org/) - Feature-rich source code editor. [![Open-Source Software][oss]](https://github.com/notepad-plus-plus/notepad-plus-plus)
 * [Notepad2](https://www.flos-freeware.ch/notepad2.html) - Lightweight Notepad replacement with enhanced features. ![Open-Source Software](/assets/opensource.svg)
+* [Quillite Markdown](https://qm.ssssa.cn/) - Lightweight, local-first Markdown reader and editor with live preview, visual diagram editing, math, and multi-format export. [![Open-Source Software][oss]](https://github.com/liuhang798/quillite-markdown)
 * [Sublime Text](https://www.sublimetext.com/3) - Advanced text editor with extensive plugin ecosystem.
 * [Text Forge](https://text-forge.github.io/docs) - Lighweight, hackable, and highly modular text & code editor. ![Open-Source Software](/assets/opensource.svg)
 


### PR DESCRIPTION
Adds Quillite Markdown to the Text Editors section.\n\nQuillite Markdown is an MIT-licensed, local-first Markdown reader and editor for Windows, macOS, and Linux. It uses Go and Wails instead of Electron and supports live preview, visual Mermaid/ECharts editing, math, and multi-format export.\n\nOfficial website: https://qm.ssssa.cn/\nSource: https://github.com/liuhang798/quillite-markdown