### PR TITLE
Add YazSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ More information in CLAUDE.md and llms.txt.
 * [TypeWhisper](https://www.typewhisper.com) - Local speech-to-text transcription with privacy-first approach. System-wide dictation via global hotkey. [![Open-Source Software][oss]](https://github.com/TypeWhisper/typewhisper-win)
 * [ToDoList](https://abstractspoon.com/) - Feature-rich task management tool. [![Open-Source Software][oss]](https://github.com/abstractspoon/ToDoList)
 * [WordWeb](https://wordweb.info/) - Comprehensive English dictionary.
+* [YazSes](https://mskazemi.com/yazses/) - Offline hold-to-talk voice dictation that types into any app. Transcribes on your CPU with no cloud, account, or API key. [![Open-Source Software][oss]](https://github.com/MSKazemi/yazses)
 * [Saga Reader](https://github.com/sopaco/saga-reader) - A Blazing-Fast and Extremely-Lightweight Internet Reader driven by AI.Supports fetching of search engine information and RSS.
 * [EyeRest](https://github.com/necdetsanli/EyeRest) - A lightweight Windows tray application that gently reminds you to follow the 20–20–20 rule:
 every 20 minutes, look at something 20 feet (~6 meters) away for at least 20 seconds. [![Open-Source Software][oss]](https://github.com/necdetsanli/EyeRest)


### PR DESCRIPTION
Adds **YazSes** to Productivity.

**Disclosure: I am the author of this project.**

[YazSes](https://github.com/MSKazemi/yazses) is offline hold-to-talk voice dictation for Windows, Linux and macOS. You hold a key, speak, release, and the text is typed into whatever window has focus — so it works in any application rather than only inside a dedicated dictation box. Transcription runs locally on the CPU via faster-whisper; there is no cloud service, no account, and no API key.

It sits alongside TypeWhisper, already in this category, and differs in adding voice commands, speaker-labelled meeting capture, and published benchmarks.

Why I think it clears the bar in the CAUTION notice:

- Apache-2.0, public since June 2026, 1300+ commits.
- Installable on Windows via `winget install MSKazemi.YazSes` — the package was moderator-approved and merged into `microsoft/winget-pkgs` on 2026-09-10. Also on Scoop, and as a signed-checksum `.exe` with SLSA provenance.
- CI runs the full suite on Windows, Linux and macOS across Python 3.11–3.14; 13,821 tests currently pass.
- There is a paper describing the system and its measured accuracy: [arXiv:2607.28878](https://arxiv.org/abs/2607.28878).
- Privacy is enforced mechanically rather than promised: a test enumerates every module allowed to open an outbound connection and fails the build if any module gains an unregistered one.

Guideline check: entry is in alphabetical position within Productivity, uses the existing `[oss]` badge reference, single suggestion in this PR, no trailing whitespace, links to the homepage with the badge pointing at the repo.
